### PR TITLE
Added `node-fetch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babylon": "^6.17.2",
     "diff": "^3.2.0",
     "lodash": "^4.16.1",
+    "node-fetch": "^2.1.2",
     "platform": "^1.3.4",
     "pubnub": "^4.3.3",
     "recast": "^0.12.4",


### PR DESCRIPTION
Hey, I noticed, that `node-fetch` dependency is missing.

Currently, the methods that rely on fetch e.g. `session.saveAsync();` throw compiler error.


```
// SnackSession.js

import PubNub from 'pubnub';
import shortid from 'shortid';
import debounce from 'lodash/debounce';
import pull from 'lodash/pull';
import isEqual from 'lodash/isEqual';
import pickBy from 'lodash/pickBy';
import cloneDeep from 'lodash/cloneDeep';
import difference from 'lodash/difference';
import compact from 'lodash/compact';
import { parse, print } from 'recast';
import * as babylon from 'babylon';
import semver from 'semver';
import validate from 'validate-npm-package-name';
import fetch from 'node-fetch'; // <= HERE

...

saveAsync = async () => {

    ...

    try {
      const response = await fetch(url, { // <== AND HERE
        method: 'POST',
        body: JSON.stringify(payload),
        headers: {
          'Content-Type': 'application/json',
          ...(this.authorizationToken
            ? { Authorization: `Bearer ${this.authorizationToken}` }
            : {}),
          ...(this.sessionSecret ? { 'Expo-Session': this.sessionSecret } : {}),
        },
      });
      const data = await response.json();

...

  };
```