### PR TITLE
Update URL returned from Snack saveAsync

### DIFF
--- a/src/SnackSession.js
+++ b/src/SnackSession.js
@@ -501,7 +501,7 @@ export default class SnackSession {
         this._sendStateEvent();
         let fullName;
         if (data.id.match(/.*\/.*/)) {
-          fullName = data.id.replace('@snack', '');
+          fullName = data.id.replace('@snack/', '');
         } else {
           fullName = data.id;
         }

--- a/src/SnackSession.js
+++ b/src/SnackSession.js
@@ -501,16 +501,16 @@ export default class SnackSession {
         this._sendStateEvent();
         let fullName;
         if (data.id.match(/.*\/.*/)) {
-          fullName = data.id;
+          fullName = data.id.replace('@snack', '');
         } else {
-          fullName = `@snack/${data.id}`;
+          fullName = data.id;
         }
 
         this._requestStatus();
         this.snackId = data.id;
         return {
           id: data.id,
-          url: `https://expo.io/${fullName}`,
+          url: `https://snack.expo.io/${data.id}`,
         };
       } else {
         throw new Error(

--- a/src/SnackSession.js
+++ b/src/SnackSession.js
@@ -510,7 +510,7 @@ export default class SnackSession {
         this.snackId = data.id;
         return {
           id: data.id,
-          url: `https://snack.expo.io/${data.id}`,
+          url: `https://snack.expo.io/${fullName}`,
         };
       } else {
         throw new Error(


### PR DESCRIPTION
When saving a Snack, the url returned is in the format `https://expo.io/@snack/id`. This takes the user to a "Looking for Snack?" page, with a link that sends them to `https://snack.expo.io/@snack/id`, which is an invalid page. This PR updates the url returned from the SDK to be in the proper format, `https://snack.expo.io/id`.